### PR TITLE
fix issue #6 - "completion" block is not called when a popover is used.

### DIFF
--- a/JVAlertController/JVAlertController/UIViewController+JVAlertController.m
+++ b/JVAlertController/JVAlertController/UIViewController+JVAlertController.m
@@ -152,8 +152,19 @@ static void JVAC_DismissViewController(UIViewController *self,
         && UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         
         [self.JVAC_popoverHostController.JVAC_popoverController dismissPopoverAnimated:flag];
-        self.JVAC_popoverHostController.JVAC_popoverController = nil;
-        self.JVAC_popoverHostController = nil;
+        // call completion immediatedly
+        if (completion != NULL) {
+            @try {
+                completion();
+            } @finally {
+                self.JVAC_popoverHostController.JVAC_popoverController = nil;
+                self.JVAC_popoverHostController = nil;
+            }
+        } else {
+            self.JVAC_popoverHostController.JVAC_popoverController = nil;
+            self.JVAC_popoverHostController = nil;
+        }
+
         return;
     }
     


### PR DESCRIPTION
Dismissing the alert view did not call the "completion" block properly if
it was presented using a popover. The dismissal function of the popover controller
does not provide a proper parameter to pass the "completion" block.
The block needs to be called immediately after dismissing the popover.
