### PR TITLE
implemment UIPopoverPresentationController.delegate mechanism.

### DIFF
--- a/JVAlertController/JVAlertController/JVPopoverPresentationController.m
+++ b/JVAlertController/JVAlertController/JVPopoverPresentationController.m
@@ -35,7 +35,7 @@
 @property(nonatomic, copy) UIColor *backgroundColor;
 @property(nonatomic, copy) NSArray *passthroughViews;
 @property(nonatomic, readwrite, strong) Class< UIPopoverBackgroundViewMethods > popoverBackgroundViewClass;
-@property(nonatomic, weak) UIPopoverArrowDirection permittedArrowDirections;
+@property(nonatomic, assign) UIPopoverArrowDirection permittedArrowDirections;
 @property(nonatomic, readonly) UIPopoverArrowDirection arrowDirection;
 @property(nonatomic, readwrite, weak) UIPopoverController *jv_legacyPopoverController;
 @end

--- a/JVAlertController/JVAlertController/JVPopoverPresentationController.m
+++ b/JVAlertController/JVAlertController/JVPopoverPresentationController.m
@@ -44,7 +44,7 @@
 
 @dynamic popoverLayoutMargins, backgroundColor, passthroughViews, popoverBackgroundViewClass, arrowDirection;
 
-- (UIEdgeInsets)getPopoverLayoutMargins {
+- (UIEdgeInsets)popoverLayoutMargins {
     return self.jv_legacyPopoverController.popoverLayoutMargins;
 }
 
@@ -52,7 +52,7 @@
     self.jv_legacyPopoverController.popoverLayoutMargins = newLayoutMargins;
 }
 
-- (UIColor*)getBackgroundColor {
+- (UIColor*)backgroundColor {
     return self.jv_legacyPopoverController.backgroundColor;
 }
 
@@ -60,7 +60,7 @@
     self.jv_legacyPopoverController.backgroundColor = newColor;
 }
 
-- (NSArray*)getPassthroughViews {
+- (NSArray*)passthroughViews {
     return self.jv_legacyPopoverController.passthroughViews;
 }
 
@@ -68,7 +68,7 @@
     self.jv_legacyPopoverController.passthroughViews = newViews;
 }
 
-- (Class< UIPopoverBackgroundViewMethods >)getPopoverBackgroundViewClass {
+- (Class< UIPopoverBackgroundViewMethods >)popoverBackgroundViewClass {
     return self.jv_legacyPopoverController.popoverBackgroundViewClass;
 }
 
@@ -76,7 +76,7 @@
     self.jv_legacyPopoverController.popoverBackgroundViewClass = newClass;
 }
 
-- (UIPopoverArrowDirection)getArrowDirection {
+- (UIPopoverArrowDirection)arrowDirection {
     return self.jv_legacyPopoverController.popoverArrowDirection;
 }
 

--- a/JVAlertController/JVAlertController/JVPopoverPresentationController.m
+++ b/JVAlertController/JVAlertController/JVPopoverPresentationController.m
@@ -26,13 +26,91 @@
 #import <objc/runtime.h>
 #import <UIKit/UIKit.h>
 
-@interface JVPopoverPresentationController : NSObject
+@interface JVPopoverPresentationController : NSObject <UIPopoverControllerDelegate>
 @property (nonatomic, strong) UIView *sourceView;
 @property (nonatomic) CGRect sourceRect;
 @property (nonatomic, strong) UIBarButtonItem *barButtonItem;
+@property (nonatomic, weak) id<UIPopoverPresentationControllerDelegate> delegate;
+@property(nonatomic, readwrite) UIEdgeInsets popoverLayoutMargins;
+@property(nonatomic, copy) UIColor *backgroundColor;
+@property(nonatomic, copy) NSArray *passthroughViews;
+@property(nonatomic, readwrite, strong) Class< UIPopoverBackgroundViewMethods > popoverBackgroundViewClass;
+@property(nonatomic, weak) UIPopoverArrowDirection permittedArrowDirections;
+@property(nonatomic, readonly) UIPopoverArrowDirection arrowDirection;
+@property(nonatomic, readwrite, weak) UIPopoverController *jv_legacyPopoverController;
 @end
 
 @implementation JVPopoverPresentationController
+
+@dynamic popoverLayoutMargins, backgroundColor, passthroughViews, popoverBackgroundViewClass, arrowDirection;
+
+- (UIEdgeInsets)getPopoverLayoutMargins {
+    return self.jv_legacyPopoverController.popoverLayoutMargins;
+}
+
+- (void)setPopoverLayoutMargins:(UIEdgeInsets)newLayoutMargins {
+    self.jv_legacyPopoverController.popoverLayoutMargins = newLayoutMargins;
+}
+
+- (UIColor*)getBackgroundColor {
+    return self.jv_legacyPopoverController.backgroundColor;
+}
+
+- (void)setBackgroundColor:(UIColor*)newColor {
+    self.jv_legacyPopoverController.backgroundColor = newColor;
+}
+
+- (NSArray*)getPassthroughViews {
+    return self.jv_legacyPopoverController.passthroughViews;
+}
+
+- (void)setPassthroughViews:(NSArray*)newViews {
+    self.jv_legacyPopoverController.passthroughViews = newViews;
+}
+
+- (Class< UIPopoverBackgroundViewMethods >)getPopoverBackgroundViewClass {
+    return self.jv_legacyPopoverController.popoverBackgroundViewClass;
+}
+
+- (void)setPopoverBackgroundViewClass:(Class< UIPopoverBackgroundViewMethods >)newClass {
+    self.jv_legacyPopoverController.popoverBackgroundViewClass = newClass;
+}
+
+- (UIPopoverArrowDirection)getArrowDirection {
+    return self.jv_legacyPopoverController.popoverArrowDirection;
+}
+
+- (void)popoverController:(UIPopoverController *)popoverController
+willRepositionPopoverToRect:(inout CGRect *)rect
+                   inView:(inout UIView **)view {
+
+    if (self.delegate != nil && [self.delegate respondsToSelector:@selector(popoverPresentationController:willRepositionPopoverToRect:inView:)]) {
+
+        [self.delegate popoverPresentationController:(UIPopoverPresentationController*)self
+                         willRepositionPopoverToRect:rect
+                                              inView:view
+         ];
+    }
+}
+
+- (BOOL)popoverControllerShouldDismissPopover:(UIPopoverController *)popoverController {
+
+    if (self.delegate != nil && [self.delegate respondsToSelector:@selector(popoverPresentationControllerShouldDismissPopover:)]) {
+
+        return [self.delegate popoverPresentationControllerShouldDismissPopover:(UIPopoverPresentationController*)self];
+    }
+    return YES;
+}
+
+- (void)popoverControllerDidDismissPopover:(UIPopoverController *)popoverController {
+
+    if (self.delegate != nil && [self.delegate respondsToSelector:@selector(popoverPresentationControllerDidDismissPopover:)]) {
+
+        [self.delegate popoverPresentationControllerDidDismissPopover:(UIPopoverPresentationController*)self];
+    }
+}
+
+
 
 // copy the JVPopoverPresentationController implementation into UIPopoverPresentationController's place on iOS 7
 // adapted from Cédric Luthi's NSUUID project: https://github.com/0xced/NSUUID

--- a/JVAlertController/JVAlertController/UIViewController+JVAlertController.m
+++ b/JVAlertController/JVAlertController/UIViewController+JVAlertController.m
@@ -119,7 +119,14 @@ static void JVAC_PresentViewController(UIViewController *self,
             
             self.JVAC_popoverController =
             [[UIPopoverController alloc] initWithContentViewController:viewControllerToPresent];
-            
+
+            if ([ppc respondsToSelector:@selector(setJv_legacyPopoverController:)]) {
+                [ppc performSelector:@selector(setJv_legacyPopoverController:) withObject:self.JVAC_popoverController];
+            }
+            if ([ppc conformsToProtocol:@protocol(UIPopoverControllerDelegate)]) {
+                self.JVAC_popoverController.delegate = (id<UIPopoverControllerDelegate>)ppc;
+            }
+
             viewControllerToPresent.JVAC_popoverHostController = self;
             
             if (ppc.barButtonItem) {


### PR DESCRIPTION
previously the popover delegation methods were not being handled
because the related delegate class in iOS8
("UIPopoverPresentationControllerDelegate") does not exist in
iOS<=7. Furtunately this new delegate is very similar to
UIPopoverControllerDelegate and therefore it seemed possible
to catch calls to the old delegate type and pass them to
the new one.

JVPopoverPresentationController is the glue between old and
new delegate type. It facedes UIPopoverController to implement
properties of the new type UIPopoverPresentationController.
